### PR TITLE
Use Test::More rather than raw TAP in tests

### DIFF
--- a/t/dot_dot.t
+++ b/t/dot_dot.t
@@ -1,36 +1,18 @@
+#!perl
+
 use strict;
-use vars qw($test $ok $total);
-sub OK { print "ok " . $test++ . "\n" }
-sub NOT_OK { print "not ok " . $test++ . "\n"};
+use warnings;
 
-BEGIN { $test = 1; $ok=0; $| = 1 }
-END { NOT_OK unless $ok }
+use Test::More 0.88 tests => 4;
 
-use enum;
-
-$ok++;
-OK;
-
-use enum qw(Foo Bar Cat Dog);
 use enum qw(
-	:Months_=0 Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec
-	:Days_     Sun=0 Mon Tue Wed Thu Fri Sat
 	:Letters_=0 A..Z
 	:=0
 	: A..Z
-	Ten=10	Forty=40	FortyOne	FortyTwo
-	Zero=0	One			Two			Three=3	Four
-	:=100
 );
 
-#2
-(Letters_A != 0 or Letters_Z != 25)
-	? NOT_OK
-	: OK;
+cmp_ok Letters_A, '==', 0,  'Letters_A';
+cmp_ok Letters_Z, '==', 25, 'Letters_Z';
 
-#3
-(A != 0 or Z != 25)
-	? NOT_OK
-	: OK;
-
-BEGIN { $total = 3; print "1..$total\n" }
+cmp_ok A, '==', 0,  'A';
+cmp_ok Z, '==', 25, 'Z';

--- a/t/new_index.t
+++ b/t/new_index.t
@@ -1,36 +1,22 @@
+#!perl
+
 use strict;
-use vars qw($test $ok $total);
-sub OK { print "ok " . $test++ . "\n" }
-sub NOT_OK { print "not ok " . $test++ . "\n"};
+use warnings;
 
-BEGIN { $test = 1; $ok=0; $| = 1 }
-END { NOT_OK unless $ok }
+use Test::More 0.88 tests => 9;
 
-use enum;
-
-$ok++;
-OK;
-
-use enum qw(Foo Bar Cat Dog);
 use enum qw(
-	:Months_=0 Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec
-	:Days_     Sun=0 Mon Tue Wed Thu Fri Sat
-	:Letters_=0 A..Z
-	:=0
-	: A..Z
 	Ten=10	Forty=40	FortyOne	FortyTwo
 	Zero=0	One			Two			Three=3	Four
-	:=100
 );
 
-#2
-(Zero != 0 or One != 1 or Two != 2 or Three != 3 or Four != 4)
-	? NOT_OK
-	: OK;
+cmp_ok Zero,  '==', 0, 'Zero';
+cmp_ok One,   '==', 1, 'One';
+cmp_ok Two,   '==', 2, 'Two';
+cmp_ok Three, '==', 3, 'Three';
+cmp_ok Four,  '==', 4, 'Four';
 
-#3
-(Ten != 10 or Forty != 40 or FortyOne != 41 or FortyTwo != 42)
-	? NOT_OK
-	: OK;
-
-BEGIN { $total = 3; print "1..$total\n" }
+cmp_ok Ten,      '==', 10, 'Ten';
+cmp_ok Forty,    '==', 40, 'Forty';
+cmp_ok FortyOne, '==', 41, 'FortyOne';
+cmp_ok FortyTwo, '==', 42, 'FortyTwo';

--- a/t/new_package.t
+++ b/t/new_package.t
@@ -1,28 +1,13 @@
+#!perl
+
 use strict;
-use vars qw($test $ok $total @foo);
-sub OK { print "ok " . $test++ . "\n" }
-sub NOT_OK { print "not ok " . $test++ . "\n"};
+use warnings;
 
-BEGIN { $test = 1; $ok=0; $| = 1 }
-END { NOT_OK unless $ok }
-
-use enum;
-
-$ok++;
-OK;
+use Test::More 0.88 tests => 4;
 
 use enum qw(Foo Bar Cat Dog);
-use enum qw(
-	:Months_=0 Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec
-	:Days_     Sun=0 Mon Tue Wed Thu Fri Sat
-	:Letters_=0 A..Z
-	:=0
-	: A..Z
-	Ten=10	Forty=40	FortyOne	FortyTwo
-	Zero=0	One			Two			Three=3	Four
-	:=100
-);
 
+my @foo;
 $foo[Foo] = "Foo";
 $foo[Bar] = "Bar";
 $foo[Cat] = "Cat";
@@ -33,16 +18,7 @@ $foo[Dog] = "Dog";
 	use enum qw(Foo Bar Cat Dog);
 }
 
-if (
-	$foo[F::Foo]    ne "Foo"
-	or $foo[F::Bar] ne "Bar"
-	or $foo[F::Cat] ne "Cat"
-	or $foo[F::Dog] ne "Dog"
-) {
-	NOT_OK;
-}
-else {
-	OK;
-}
-
-BEGIN { $total = 2; print "1..$total\n" }
+is $foo[F::Foo], 'Foo', 'F::Foo';
+is $foo[F::Bar], 'Bar', 'F::Bar';
+is $foo[F::Cat], 'Cat', 'F::Cat';
+is $foo[F::Dog], 'Dog', 'F::Dog';

--- a/t/new_tag.t
+++ b/t/new_tag.t
@@ -1,35 +1,17 @@
+#!perl
+
 use strict;
-use vars qw($test $ok $total);
-sub OK { print "ok " . $test++ . "\n" }
-sub NOT_OK { print "not ok " . $test++ . "\n"};
+use warnings;
 
-BEGIN { $test = 1; $ok=0; $| = 1 }
-END { NOT_OK unless $ok }
+use Test::More 0.88 tests => 4;
 
-use enum;
-
-$ok++;
-OK;
-
-use enum qw(Foo Bar Cat Dog);
 use enum qw(
 	:Months_=0 Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec
 	:Days_     Sun=0 Mon Tue Wed Thu Fri Sat
-	:Letters_=0 A..Z
-	:=0
-	: A..Z
-	Ten=10	Forty=40	FortyOne	FortyTwo
-	Zero=0	One			Two			Three=3	Four
-	:=100
 );
 
-#2
-(Months_Apr != 3 or Months_Dec != 11)
-	? NOT_OK
-	: OK;
-#3
-(Days_Thu != 4 or Days_Sat != 6)
-	? NOT_OK
-	: OK;
+cmp_ok Months_Apr, '==', 3,  'Months_Apr';
+cmp_ok Months_Dec, '==', 11, 'Months_Dec';
 
-BEGIN { $total = 3; print "1..$total\n" }
+cmp_ok Days_Thu, '==', 4, 'Days_Thu';
+cmp_ok Days_Sat, '==', 6, 'Days_Sat';

--- a/t/simple_tags.t
+++ b/t/simple_tags.t
@@ -1,40 +1,21 @@
+#!perl
+
 use strict;
-use vars qw($test $ok $total @foo);
-sub OK { print "ok " . $test++ . "\n" }
-sub NOT_OK { print "not ok " . $test++ . "\n"};
+use warnings;
 
-BEGIN { $test = 1; $ok=0; $| = 1 }
-END { NOT_OK unless $ok }
-
-use enum;
-$ok++;
-OK;
+use Test::More 0.88 tests => 5;
 
 use enum qw(Foo Bar Cat Dog);
-use enum qw(
-	:Months_=0 Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec
-	:Days_     Sun=0 Mon Tue Wed Thu Fri Sat
-	:Letters_=0 A..Z
-	:=0
-	: A..Z
-	Ten=10	Forty=40	FortyOne	FortyTwo
-	Zero=0	One			Two			Three=3	Four
-	:=100
-);
 
+my @foo;
 $foo[Foo] = "Foo";
 $foo[Bar] = "Bar";
 $foo[Cat] = "Cat";
 $foo[Dog] = "Dog";
 
-#2
-(Foo != 0 or Bar != 1 or Cat != 2 or Dog != 3)
-	? NOT_OK
-	: OK;
+cmp_ok Foo, '==', 0, 'Foo';
+cmp_ok Bar, '==', 1, 'Bar';
+cmp_ok Cat, '==', 2, 'Cat';
+cmp_ok Dog, '==', 3, 'Dog';
 
-#3
-($foo[Foo] ne "Foo" or $foo[Bar] ne "Bar" or $foo[Cat] ne "Cat" or $foo[Dog] ne "Dog")
-	? NOT_OK
-	: OK;
-
-BEGIN { $total = 3; print "1..$total\n" }
+is_deeply \@foo, [qw(Foo Bar Cat Dog)], '@foo';


### PR DESCRIPTION
We already depend on Test::More in the newer tests, this makes the tests far easier to read with better diagnostics on failure too.

Also remove any enums that didn't relate to the test in question.

Tested with perl 5.34.0 / Test::More 1.302186 and perl  5.6.2 / Test::More 0.88.